### PR TITLE
Code quality tools

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+}

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,6 @@
 {
   "hooks": {
+    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
     "pre-commit": "lint-staged"
   }
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,11 @@
+{
+  "*.js": [
+    "eslint --fix",
+    "prettier --write",
+    "git add"
+  ],
+  "*.{json,css,md}": [
+    "prettier --write",
+    "git add"
+  ]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/package.json
+++ b/package.json
@@ -27,27 +27,6 @@
     "lint:templates": "eslint templates",
     "format": "prettier --write '*/**/*.{css,md,json,js}'"
   },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true,
-    "trailingComma": "es5"
-  },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "prettier --write",
-      "git add"
-    ],
-    "*.{json,css,md}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "dependencies": {
     "@babel/parser": "^7.2.2",
     "chalk": "^2.4.1",


### PR DESCRIPTION
I decided to explore the idea of the Create STRV App. I wanted to update code quality tools:

1. Move config files from `package.json` personally, I believe it is better to put as little code as possible in `package.json`
2. Make commit lint work (somebody probably accidentally removed it from husky config)

I also wanted to update eslint config but it looks like `templates/.eslintrc.js` is dependant on the root `package.json`. 🙂 